### PR TITLE
Bug/26 aboutpage

### DIFF
--- a/web/community-web/index.html
+++ b/web/community-web/index.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html lang="en-US">
-  <head>
-    <meta charset="UTF-8">
-    <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Community App</title>
-  </head>
-  <body>
-    <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
-  </body>
+<head>
+  <meta charset="UTF-8">
+  <link rel="icon" href="/favicon.ico">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#edfdf5" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#15803d" media="(prefers-color-scheme: dark)">
+  <title>Community App</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.ts"></script>
+</body>
 </html>

--- a/web/community-web/index.html
+++ b/web/community-web/index.html
@@ -1,15 +1,20 @@
 <!DOCTYPE html>
 <html lang="en-US">
+
 <head>
   <meta charset="UTF-8">
   <link rel="icon" href="/favicon.ico">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#edfdf5" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#15803d" media="(prefers-color-scheme: dark)">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
   <title>Community App</title>
 </head>
+
 <body>
   <div id="app"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>
+
 </html>

--- a/web/community-web/src/components/AboutData.vue
+++ b/web/community-web/src/components/AboutData.vue
@@ -68,7 +68,7 @@ onMounted(async () => {
         </div>
         <div class="item">
             <span>Notices:</span>
-            <span v-if="announcementCount !== null" class="status">{{ announcementCount }}</span>
+            <span v-if="announcementCount !== null" class="status">{{ announcementCount.toLocaleString('en-US') }}</span>
             <span v-if="announcementCount === null && !error" class="query">Checking...</span>
             <span v-if="announcementCount === null && error" class="status">Unknown</span>
         </div>

--- a/web/community-web/src/components/AboutData.vue
+++ b/web/community-web/src/components/AboutData.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import type { ServiceVersion } from '@/types/api'
-import type { ApiResponse } from '@/types/api'
-const status = ref<ServiceVersion | null>(null)
+import type { DbxResponse, DbxVersion } from '@/types/api'
+const status = ref<DbxVersion | null>(null)
 const error = ref<string | null>(null)
 
 const itemCount = ref<number | null>(null)
@@ -10,29 +9,33 @@ const eventCount = ref<number | null>(null)
 const announcementCount = ref<number | null>(null)
 
 onMounted(async () => {
-  try {
-    const additionalHeaders: Record<string, string> = JSON.parse(
-      import.meta.env.VITE_API_ADDITIONAL_HEADERS
-    )
-    const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/dbx/status`, {
-      headers: {
-        [import.meta.env.VITE_API_KEY_NAME]: import.meta.env.VITE_API_KEY_VALUE,
-        ...additionalHeaders,
-      },
-    })
-    if (!response.ok) {
-      error.value = `Request failed: ${response.status} ${response.statusText}`
-      return
+    try {
+        const additionalHeaders: Record<string, string> = JSON.parse(
+            import.meta.env.VITE_API_ADDITIONAL_HEADERS
+        )
+        const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/dbx/status`, {
+            headers: {
+                [import.meta.env.VITE_API_KEY_NAME]: import.meta.env.VITE_API_KEY_VALUE,
+                ...additionalHeaders,
+            },
+        })
+        if (!response.ok) {
+            error.value = `Request failed: ${response.status} ${response.statusText}`
+            return
+        }
+        const result: DbxResponse<DbxVersion> = await response.json()
+        if (result.success) {
+            status.value = result.data as DbxVersion
+            // For now, we'll just set these to dummy values since the API doesn't provide them yet
+            itemCount.value = 1234
+            eventCount.value = 567
+            announcementCount.value = 89
+        } else {
+            error.value = result.data as string
+        }
+    } catch (e) {
+        error.value = 'Offline'
     }
-    const result: ApiResponse<ServiceVersion> = await response.json()
-    if (result.isSuccess) {
-      status.value = result.data as ServiceVersion
-    } else {
-      error.value = result.data as string
-    }
-  } catch (e) {
-    error.value = 'Offline'
-  }
 })
 
 </script>
@@ -53,13 +56,13 @@ onMounted(async () => {
         </div>
         <div class="item">
             <span>Item Count:</span>
-            <span v-if="itemCount !== null" class="status">{{ itemCount }}</span>
+            <span v-if="itemCount !== null" class="status">{{ itemCount.toLocaleString('en-US') }}</span>
             <span v-if="itemCount === null && !error" class="query">Checking...</span>
             <span v-if="itemCount === null && error" class="status">Unknown</span>
         </div>
         <div class="item">
             <span>Event Count:</span>
-            <span v-if="eventCount !== null" class="status">{{ eventCount }}</span>
+            <span v-if="eventCount !== null" class="status">{{ eventCount.toLocaleString('en-US') }}</span>
             <span v-if="eventCount === null && !error" class="query">Checking...</span>
             <span v-if="eventCount === null && error" class="status">Unknown</span>
         </div>
@@ -81,30 +84,34 @@ onMounted(async () => {
     align-items: baseline;
     padding-bottom: 2rem;
 }
+
 .title {
     font-size: 1rem;
     font-weight: bold;
     grid-column: 1 / -1;
 }
+
 .item {
     display: contents;
 }
-.item > span {
-    font-size: 0.875rem;
+
+.item>span {
+    font-size: 0.75rem;
 }
 
 .status {
     color: var(--text);
     font-weight: bold;
 }
+
 .error {
     color: var(--text-error);
     font-weight: bold;
 }
+
 .query {
     color: var(--text-subtle);
     font-weight: bold;
     font-style: italic;
 }
-
 </style>

--- a/web/community-web/src/components/AboutService.vue
+++ b/web/community-web/src/components/AboutService.vue
@@ -7,29 +7,29 @@ const status = ref<ServiceVersion | null>(null)
 const error = ref<string | null>(null)
 
 onMounted(async () => {
-  try {
-    const additionalHeaders: Record<string, string> = JSON.parse(
-      import.meta.env.VITE_API_ADDITIONAL_HEADERS
-    )
-    const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/status`, {
-      headers: {
-        [import.meta.env.VITE_API_KEY_NAME]: import.meta.env.VITE_API_KEY_VALUE,
-        ...additionalHeaders,
-      },
-    })
-    if (!response.ok) {
-      error.value = `Request failed: ${response.status} ${response.statusText}`
-      return
+    try {
+        const additionalHeaders: Record<string, string> = JSON.parse(
+            import.meta.env.VITE_API_ADDITIONAL_HEADERS
+        )
+        const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/status`, {
+            headers: {
+                [import.meta.env.VITE_API_KEY_NAME]: import.meta.env.VITE_API_KEY_VALUE,
+                ...additionalHeaders,
+            },
+        })
+        if (!response.ok) {
+            error.value = `Request failed: ${response.status} ${response.statusText}`
+            return
+        }
+        const result: ApiResponse<ServiceVersion> = await response.json()
+        if (result.isSuccess) {
+            status.value = result.data as ServiceVersion
+        } else {
+            error.value = result.data as string
+        }
+    } catch (e) {
+        error.value = 'Offline'
     }
-    const result: ApiResponse<ServiceVersion> = await response.json()
-    if (result.isSuccess) {
-      status.value = result.data as ServiceVersion
-    } else {
-      error.value = result.data as string
-    }
-  } catch (e) {
-    error.value = 'Offline'
-  }
 })
 
 </script>
@@ -45,19 +45,19 @@ onMounted(async () => {
         </div>
         <div class="item">
             <span>Name:</span>
-            <span class="status">{{status?.name}}</span>
+            <span class="status">{{ status?.name }}</span>
         </div>
         <div class="item">
             <span>Description:</span>
-            <span class="status">{{status?.description}}</span>
+            <span class="status">{{ status?.description }}</span>
         </div>
         <div class="item">
             <span>Copyright:</span>
-            <span class="status">{{status?.copyright}}</span>
+            <span class="status">{{ status?.copyright }}</span>
         </div>
         <div class="item">
             <span>Version:</span>
-            <span class="status">{{status?.version}}</span>
+            <span class="status">{{ status?.version }}</span>
         </div>
     </div>
 
@@ -72,27 +72,32 @@ onMounted(async () => {
     align-items: baseline;
     padding-bottom: 2rem;
 }
+
 .title {
     font-size: 1rem;
     font-weight: bold;
     grid-column: 1 / -1;
 }
+
 .item {
     display: contents;
     font-size: 0.875rem;
 }
-.item > span {
-    font-size: 0.875rem;
+
+.item>span {
+    font-size: 0.75rem;
 }
 
 .status {
     color: var(--text);
     font-weight: bold;
 }
+
 .error {
     color: var(--text-error);
     font-weight: bold;
 }
+
 .query {
     color: var(--text-subtle);
     font-weight: bold;

--- a/web/community-web/src/types/api.ts
+++ b/web/community-web/src/types/api.ts
@@ -15,6 +15,10 @@ export interface ServiceVersion {
   version: string
 }
 
+export interface DbxVersion {
+  version: string
+}
+
 export interface Announcement {
   id: number
   title: string


### PR DESCRIPTION
This pull request updates the frontend to improve API type usage, enhance mobile support, and refine UI formatting for the community web app. The most notable changes are the migration to new API response types, improvements in mobile meta tags, and better number formatting and styling in UI components.

**API type and data handling improvements:**

* Refactored `AboutData.vue` to use new API types: replaced `ServiceVersion`/`ApiResponse` with `DbxVersion`/`DbxResponse`, and updated the logic to use the new `success` property instead of `isSuccess`. Dummy values are set for counts until the API provides real data. (`[[1]](diffhunk://#diff-e82e8fd1c040c1ce2db80d55b9260db7d37246aba4e0d6be396172da529eabe7L3-R4)`, `[[2]](diffhunk://#diff-e82e8fd1c040c1ce2db80d55b9260db7d37246aba4e0d6be396172da529eabe7L27-R32)`, `[[3]](diffhunk://#diff-6c3fb6641fe94dab81cb9b089a6f69ebaad50600e4025423390697948acc9390R18-R21)`)
* Added new `DbxVersion` interface to `api.ts` to support the updated API response structure. (`[web/community-web/src/types/api.tsR18-R21](diffhunk://#diff-6c3fb6641fe94dab81cb9b089a6f69ebaad50600e4025423390697948acc9390R18-R21)`)

**UI and formatting enhancements:**

* Updated number formatting in `AboutData.vue` to use `toLocaleString('en-US')` for better readability of item and event counts. (`[web/community-web/src/components/AboutData.vueL56-R65](diffhunk://#diff-e82e8fd1c040c1ce2db80d55b9260db7d37246aba4e0d6be396172da529eabe7L56-R65)`)
* Adjusted font sizes for `.item>span` elements in both `AboutData.vue` and `AboutService.vue` for improved visual consistency. (`[[1]](diffhunk://#diff-e82e8fd1c040c1ce2db80d55b9260db7d37246aba4e0d6be396172da529eabe7R87-L109)`, `[[2]](diffhunk://#diff-e283e7b2dca55e6a0de55f07c70bb83682f97e4ef45c1d1e01813f5f0c5a9168R75-R100)`)

**Mobile and PWA support:**

* Added meta tags in `index.html` to improve mobile and PWA support, including theme color for light/dark modes and web app capabilities. (`[web/community-web/index.htmlR3-R19](diffhunk://#diff-f65fa3d4b774bc501e33e0f773e89f0f68ca3a8597b1f588f3523c6799b9b3deR3-R19)`)